### PR TITLE
Update grid_trader.py

### DIFF
--- a/grid_trader.py
+++ b/grid_trader.py
@@ -215,7 +215,7 @@ class GridTrader:
         """计算订单数量"""
         grid_investment = self.investment / self.grid_number
         amount = grid_investment / price
-        return max(round(amount, 3), self.min_order_size)
+        return max(round(amount, 2), self.min_order_size)
 
     def check_balance(self, side: str, amount: float, price: float) -> bool:
         """检查账户余额是否足够"""


### PR DESCRIPTION
修复 Quantity decimal too long
使用 sol 现货网格时，发生的错误，amount(quantity) 精度超长了，建议限制成 2 位，然后就没请求的报错了。

日志如下：'quantity': '0.136',

2025-04-02 09:53:56,830 - INFO - backpack_exchange.py:336 - 创建订单数据: {'symbol': 'SOL_USDC', 'side': 'Bid', 'orderType': 'Limit', 'quantity': '0.136', 'timeInForce': 'GTC', 'reduceOnly': False, 'selfTradePrevention': 'RejectTaker', 'clientId': 58836828, 'postOnly': True, 'price': '123.0'}
2025-04-02 09:53:56,971 - backpack_exchange - ERROR - 未知错误: 请求失败: {"code":"INVALID_CLIENT_REQUEST","message":"Quantity decimal too long"}